### PR TITLE
Fix repair_simpack.sh to remove uncompressed log files

### DIFF
--- a/ensemble/tools/repair_simpack.sh
+++ b/ensemble/tools/repair_simpack.sh
@@ -72,7 +72,9 @@ for file in $(ls *.log || true)
 do
     if [ -f "${file}.gz" ]
     then
+        echo "both compressed and uncompressed logfile found. removing uncompressed $file "
         /bin/rm $file
+        let found+=1
     fi
 done
 

--- a/mutate/create_inputs_12ns.py
+++ b/mutate/create_inputs_12ns.py
@@ -87,8 +87,7 @@ def create_inputs():
 
     # determine the ranges for solute, solvent, and fepatoms
     solute_range, solvent_range = tools.get_solute_and_solvent_ranges(pdbfil)
-    resids = tools.get_fep_resids(pdbfil, fepfil)
-    indexes = tools.get_non_backbone_atoms(pdbfil, resids)
+    indexes = tools.get_fep_atom_pdbindexes(fepfil)
     fepranges = tools.get_ranges(indexes)
 
     tarfile.extractall()


### PR DESCRIPTION
If compressed and uncompressed log files were found by repair_simpack.sh, it would remove the uncompressed ones but not repack the simpack as the found variable was not incremented. Therefore the uncompressed logfiles would be still present in the archives after running repair_simpack.sh if no other issue with the simpack was detected.
Added incrementation of found variable and message including file name for each deleted log file.